### PR TITLE
Fix build-vendor-spec importing asset files

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ module.exports = function(gulp) {
   });
 
   gulp.task('build-vendor-spec', function() {
-    var stream = gulp.src(mainBowerFiles({includeDev: true}))
+    var stream = gulp.src(mainBowerFiles({filter: '**/*.js', includeDev: true}))
       .pipe(debug({title: 'Vendor Files:'}))
       .pipe(concat('vendor-spec.js'))
       .pipe(gulp.dest(config.build_dir))


### PR DESCRIPTION
`build-vendor-spec` was importing assets and concatenating them into `vendor-spec`, I eventually traced it back to the task in this library.
- Add filter to `mainBowerFiles` function in `build-vendor-spec` task
