### PR TITLE
build-vendor in development

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ module.exports = function(gulp) {
   });
 
   gulp.task('build-vendor', function() {
-    var stream = gulp.src(mainBowerFiles({filter: '**/*.js'}))
+    var stream = gulp.src(mainBowerFiles({filter: '**/*.js', includeDev: true}))
         .pipe(debug({title: 'Vendor Files (JS):'}))
         .pipe(concat('vendor.js'))
         .pipe(gulp.dest(config.build_dir))


### PR DESCRIPTION
Protractor requires build-vendor task for the partner_dashboard_frontend.
